### PR TITLE
Enable picante cache persistence for incremental builds

### DIFF
--- a/crates/vx-aether/src/main.rs
+++ b/crates/vx-aether/src/main.rs
@@ -319,13 +319,16 @@ async fn main() -> Result<()> {
 
     // Initialize aether service
     tracing::info!("Initializing aether service");
-    let aether = AetherHandle::new(AetherService::new(
-        cas_client,
-        exec_client,
-        args.vx_home,
-        exec_host_triple,
-        spawn_tracker,
-    ));
+    let aether = AetherHandle::new(
+        AetherService::new(
+            cas_client,
+            exec_client,
+            args.vx_home,
+            exec_host_triple,
+            spawn_tracker,
+        )
+        .await,
+    );
 
     // Start TCP server
     let listener = TcpListener::bind(&args.bind).await?;


### PR DESCRIPTION
## Summary

Re-enables picante cache persistence to unlock true incremental builds, fixing #15.

## Changes

- **Load cache on startup**: `AetherService::new()` now loads persisted cache from `~/.vx/picante.cache`
- **Save cache after builds**: Cache is persisted after successful build completion
- **Made `AetherService::new()` async** to support async cache loading
- **Removed outdated TODOs** and commented-out imports referencing blocked upstream issue
- **Graceful error handling**: Cache load/save failures log warnings but don't break builds

## Implementation

Uses convenience methods added to the `#[picante::db]` macro (upstream issue bearcove/picante#32 was recently resolved):
- `db.load_from_cache(path)` - loads all ingredients from cache file
- `db.save_to_cache(path)` - saves all ingredients to cache file

These methods automatically collect all persistable ingredients (inputs, interned values, tracked queries) without manual boilerplate.

## Impact

With persistence enabled:
- ✅ **Incremental computation**: Unchanged source files don't trigger cache key recomputation
- ✅ **Toolchain reuse**: Toolchain hashes are persisted and reused across builds
- ✅ **Near-instant rebuilds**: Second builds of unchanged code should be dramatically faster
- ✅ **Cross-session caching**: Cache survives daemon restarts

## Testing

- [x] Code compiles successfully
- [x] Cache load/save paths are robust to missing files and errors
- [x] Ready for real-world testing with actual builds

Closes #15